### PR TITLE
Fixes return codes and messages in case of a payload with empty items on patch actions

### DIFF
--- a/models.py
+++ b/models.py
@@ -122,10 +122,12 @@ class MaintenanceWindow:
             raise ValueError('Start in the past not allowed.')
         if end < start:
             raise ValueError('End before start not allowed.')
+        if 'items' in mw_dict:
+            if not mw_dict['items']:
+                raise ValueError('At least one item must be provided')
+            self.items = mw_dict['items']
         self.start = start
         self.end = end
-        if 'items' in mw_dict and mw_dict['items']:
-            self.items = mw_dict['items']
         if 'description' in mw_dict:
             self.description = mw_dict['description']
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -487,6 +487,38 @@ class TestMain(TestCase):
                          'End before start not allowed.')
         mw_update_mock.assert_called_once_with(payload)
 
+    @patch('napps.kytos.maintenance.models.MaintenanceWindow.update')
+    def test_update_mw_case_6(self, mw_update_mock):
+        """Test successful update."""
+        start1 = datetime.now(pytz.utc) + timedelta(days=1)
+        end1 = start1 + timedelta(hours=6)
+        start2 = datetime.now(pytz.utc) + timedelta(hours=5)
+        end2 = start2 + timedelta(hours=1, minutes=30)
+        self.napp.maintenances = {
+            '1234': MW(start1, end1, self.controller, items=[
+                '00:00:00:00:00:00:12:23'
+            ]),
+            '4567': MW(start2, end2, self.controller, items=[
+                '12:34:56:78:90:ab:cd:ef'
+            ])
+        }
+        start_new = datetime.utcnow() + timedelta(days=1, hours=3)
+        payload = {
+            "start": start_new.strftime(TIME_FMT),
+            "items": []
+        }
+        mw_update_mock.side_effect = ValueError('At least one item must be provided')
+
+        url = f'{self.server_name_url}/1234'
+        response = self.api.patch(url, data=json.dumps(payload),
+                                  content_type='application/json')
+        current_data = json.loads(response.data)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(current_data, 'At least one item must be provided')
+        mw_update_mock.assert_called_once_with(payload)
+        self.assertEqual(self.napp.maintenances['1234'].start, start1)
+        self.assertEqual(self.napp.maintenances['1234'].end, end1)
+
     def test_end_mw_case_1(self):
         """Test method that finishes the maintenance now."""
         start1 = datetime.now(pytz.utc) + timedelta(days=1)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -514,7 +514,8 @@ class TestMain(TestCase):
                                   content_type='application/json')
         current_data = json.loads(response.data)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(current_data, 'At least one item must be provided')
+        self.assertEqual(current_data['description'],
+                         'At least one item must be provided')
         mw_update_mock.assert_called_once_with(payload)
         self.assertEqual(self.napp.maintenances['1234'].start, start1)
         self.assertEqual(self.napp.maintenances['1234'].end, end1)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -49,11 +49,6 @@ class TestMW(TestCase):
 
     def test_update_empty_items(self):
         """Test failed update."""
-        self.maintenance.update({'items': []})
-        self.assertEqual(self.maintenance.items, self.items)
-
-    def test_update_empty_items_2(self):
-        """Test failed update."""
         with self.assertRaises(ValueError):
             self.maintenance.update({'items': []})
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -52,6 +52,11 @@ class TestMW(TestCase):
         self.maintenance.update({'items': []})
         self.assertEqual(self.maintenance.items, self.items)
 
+    def test_update_empty_items_2(self):
+        """Test failed update."""
+        with self.assertRaises(ValueError):
+            self.maintenance.update({'items': []})
+
     def test_update_items(self):
         """Test update items parameter."""
         items = ["09:87:65:43:21:fe:dc:ba"]


### PR DESCRIPTION
It fixes issue #9.

### **Description of the change**
The proposed implementation modifies the models.py file, specifically the update method, to check the item field's content. This contribution prevents the update or patching process in case an empty payload has been provided.

It is included new unit tests to support code changes.