### PR TITLE
Modifications over returning errors associated with Patch and Post actions

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,7 +131,7 @@ class Main(KytosNApp):
         self.scheduler.remove(maintenance)
         maintenance.end_mw()
         return jsonify({'response': f'Maintenance window {mw_id} '
-                                    f'finished.'}), 200
+                                    f'finished.'}), 201
 
     @rest('/<mw_id>/extend', methods=['PATCH'])
     def extend_mw(self, mw_id):

--- a/openapi.yml
+++ b/openapi.yml
@@ -45,7 +45,7 @@ paths:
             schema:
               $ref: '#/components/schemas/MaintenanceWindow'
       responses:
-        '201':
+        '200':
            description: Maintenance window created.
            content:
              application/json:
@@ -180,7 +180,7 @@ paths:
                 minutes:
                   type: integer        
       responses:
-        '200':
+        '201':
           description: Maintenance window succesfully extended
           content:
             application/json:

--- a/openapi.yml
+++ b/openapi.yml
@@ -112,7 +112,7 @@ paths:
             schema:
               $ref: '#/components/schemas/MaintenanceWindow'
       responses:
-        '200':
+        '201':
           description: Maintenance window sucessfully updated
         '400':
           description: Malformed request body

--- a/openapi.yml
+++ b/openapi.yml
@@ -45,7 +45,7 @@ paths:
             schema:
               $ref: '#/components/schemas/MaintenanceWindow'
       responses:
-        '200':
+        '201':
            description: Maintenance window created.
            content:
              application/json:

--- a/openapi.yml
+++ b/openapi.yml
@@ -118,6 +118,8 @@ paths:
           description: Malformed request body
         '404':
           description: Maintenance window not found.
+        '415':
+          description: No JSON in request.
     delete:
       tags:
         - Delete


### PR DESCRIPTION
## Description of the Change
- It is fixed the patching action on '/<mw_id>/end,' returning 201 in case of success.


- It is fixed the posting action on '/maintenance' specifying 200 in case of success
- It is included a new error code on the patch action on '/maintenance/{mw_id}' to specify "No JSON in request."

## Release Notes
N/A