### PR TITLE
Modifications over returning errors associated with Patch actions

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,7 +131,7 @@ class Main(KytosNApp):
         self.scheduler.remove(maintenance)
         maintenance.end_mw()
         return jsonify({'response': f'Maintenance window {mw_id} '
-                                    f'finished.'}), 200
+                                    f'finished.'}), 201
 
     @rest('/<mw_id>/extend', methods=['PATCH'])
     def extend_mw(self, mw_id):

--- a/openapi.yml
+++ b/openapi.yml
@@ -112,12 +112,14 @@ paths:
             schema:
               $ref: '#/components/schemas/MaintenanceWindow'
       responses:
-        '200':
+        '201':
           description: Maintenance window sucessfully updated
         '400':
           description: Malformed request body
         '404':
           description: Maintenance window not found.
+        '415':
+          description: No JSON in request.
     delete:
       tags:
         - Delete

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -559,7 +559,7 @@ class TestMain(TestCase):
         url = f'{self.server_name_url}/1234/end'
         response = self.api.patch(url)
         current_data = json.loads(response.data)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 201)
         self.assertEqual(current_data,
                          {'response': 'Maintenance window 1234 finished.'})
         end_mw_mock.assert_called_once()


### PR DESCRIPTION
Fixes #18 

## Description of the Change
- It is fixed the patching action on '/<mw_id>/end,' returning 201 in case of success.

_On Tests_
- It is modified the test code relative to the patching action on '/<mw_id>/end,' which returns 201 in case of success.

_On Documentation_
- It is included a new error code on the patch action on '/maintenance/{mw_id}' to specify "No JSON in request."
- It is modified the response code in case of succeeding


## Release Notes
N/A