### PR TITLE
Modifications over returning errors associated with Patch actions

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,7 +98,7 @@ class Main(KytosNApp):
             raise BadRequest(f'{error}')
         self.scheduler.remove(maintenance)
         self.scheduler.add(maintenance)
-        return jsonify({'response': f'Maintenance {mw_id} updated'}), 201
+        return jsonify({'response': f'Maintenance {mw_id} updated'}), 200
 
     @rest('/<mw_id>', methods=['DELETE'])
     def remove_mw(self, mw_id):

--- a/openapi.yml
+++ b/openapi.yml
@@ -118,6 +118,8 @@ paths:
           description: Malformed request body
         '404':
           description: Maintenance window not found.
+        '415':
+          description: No JSON in request.
     delete:
       tags:
         - Delete
@@ -149,7 +151,7 @@ paths:
             type: string
           description: Maintenance window ID
       responses:
-        '201':
+        '200':
           description: Maintenance window succesfully finished
         '400':
           description: Invalid data.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -418,7 +418,7 @@ class TestMain(TestCase):
         response = self.api.patch(url, data=json.dumps(payload),
                                   content_type='application/json')
         current_data = json.loads(response.data)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(current_data,
                          {'response': 'Maintenance 1234 updated'})
         mw_update_mock.assert_called_once_with(payload)


### PR DESCRIPTION
PR
Fixes #22 and #23

## Description of the Change
- It is fixed the patching action on '/maintenance/{mw_id},' returning 200 in case of success.

_On Tests_
- It is modified the test code relative to the patching action on '/maintenance/{mw_id},' which should return 200 in case of success.

_On Documentation_
- It is modified the response code in case of succeeding the API call '/maintenance/{mw_id}/end' on Patch
- It is included a new error code on the patch action '/maintenance/{mw_id}' to specify "No JSON in request."


## Release Notes
N/A