### PR TITLE
[Fix] Updated README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
   <div align="center">
     <h1><code>kytos/maintenance</code></h1>
 
-    <strong>NApp that finds network paths</strong>
+    <strong>NApp that manages maintenance windows</strong>
 
     <h3><a href="https://kytos-ng.github.io/api/maintenance.html">OpenAPI Docs</a></h3>
   </div>

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,16 @@
+|Tag| |License| |Build| |Coverage| |Quality|
+
+.. raw:: html
+
+  <div align="center">
+    <h1><code>kytos/maintenance</code></h1>
+
+    <strong>NApp that finds network paths</strong>
+
+    <h3><a href="https://kytos-ng.github.io/api/maintenance.html">OpenAPI Docs</a></h3>
+  </div>
+
+
 Overview
 ========
 
@@ -7,7 +20,40 @@ using those devices will be moved to another path during the maintenance, if
 possible. Notifications about those devices will be disabled during the
 maintenance.
 
-Requirements
-============
-This NApp requires the `apscheduler` python package to schedule the
-maintenances.
+Events
+======
+
+Published
+---------
+
+kytos/maintenance.(start|end)_(switch|uni|link}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event reporting when a maintenance starts and ends for a switch, uni or link.
+
+Content:
+
+.. code-block:: python3
+
+   {
+     'switches|unis|links': List of <object>s,
+   }
+
+
+.. TAGs
+
+.. |License| image:: https://img.shields.io/github/license/kytos-ng/kytos.svg
+   :target: https://github.com/kytos-ng/ /blob/master/LICENSE
+.. |Build| image:: https://scrutinizer-ci.com/g/kytos-ng/maintenance/badges/build.png?b=master
+  :alt: Build status
+  :target: https://scrutinizer-ci.com/g/kytos-ng/maintenance/?branch=master
+.. |Coverage| image:: https://scrutinizer-ci.com/g/kytos-ng/maintenance/badges/coverage.png?b=master
+  :alt: Code coverage
+  :target: https://scrutinizer-ci.com/g/kytos-ng/maintenance/?branch=master
+.. |Quality| image:: https://scrutinizer-ci.com/g/kytos-ng/maintenance/badges/quality-score.png?b=master
+  :alt: Code-quality score
+  :target: https://scrutinizer-ci.com/g/kytos-ng/maintenance/?branch=master
+.. |Stable| image:: https://img.shields.io/badge/stability-stable-green.svg
+   :target: https://github.com/kytos-ng/maintenance
+.. |Tag| image:: https://img.shields.io/github/tag/kytos-ng/maintenance.svg
+   :target: https://github.com/kytos-ng/maintenance/tags


### PR DESCRIPTION
Updated readme, following the same pattern as we have for mef_eline and flow_manager

- Intentionally didn't add the `|Stable|` shield yet since there are some important well known issues that we haven't prioritized
- Removed `requirements` section since on setup.py develop it's installing the dependencies (same as we have on other napps)
- Added banner
- Documented existing published events
