### PR TITLE
Freeze pytest version to be compatible with py3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -287,7 +287,7 @@ setup(name=f'kytos_{NAPP_NAME}',
       license='MIT',
       install_requires=read_requirements(),
       setup_requires=['pytest-runner'],
-      tests_require=['pytest'],
+      tests_require=['pytest==7.0.0'],
       extras_require={
           'dev': [
               'coverage',


### PR DESCRIPTION
pytest has dropped for py3.6, as mentioned on [kytos issue 193](https://github.com/kytos-ng/kytos/issues/193), so this is PR freezes pytest version in the meantime until we drop support for py3.6 and upgrade the unit tests to run on newer python version as we have mapped on `epic_ci`. 