### PR TITLE
[Release][Fix] Shallow copy on maintenance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,14 @@ Security
 Changed
 =======
 
+[2022.2.1] - 2022-08-15
+***********************
+
+Fixed
+=====
+- Made a shallow copy when iterating on shared data structure to avoid RuntimeError size changed
+
+
 [2022.2.0] - 2022-08-08
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "maintenance",
   "description": "This NApp creates maintenance windows, allowing the maintenance of network devices (switch, link, and interface) without receiving alerts.",
-  "version": "2022.2.0",
+  "version": "2022.2.1",
   "napp_dependencies": [],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ class Main(KytosNApp):
         if mw_id is None:
             return jsonify(
                 [maintenance.as_dict()
-                 for maintenance in self.maintenances.values()]), 200
+                 for maintenance in self.maintenances.copy().values()]), 200
         try:
             return jsonify(self.maintenances[mw_id].as_dict()), 200
         except KeyError:


### PR DESCRIPTION
Fixes #56 

- Shallow copy on maintenance to avoid RuntimeError size changed
- Bumped 2022.2.1
- Updated changelog.rst