### PR TITLE
Updated endpoints to include version number `/v1`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Added
 Changed
 =======
 
+- Updated REST API endpoints to include version numbers. Current version is `\v1`.
+
 Deprecated
 ==========
 

--- a/main.py
+++ b/main.py
@@ -46,8 +46,8 @@ class Main(KytosNApp):
         If you have some cleanup procedure, insert it here.
         """
 
-    @rest('/', methods=['GET'])
-    @rest('/<mw_id>', methods=['GET'])
+    @rest('/v1', methods=['GET'])
+    @rest('/v1/<mw_id>', methods=['GET'])
     def get_mw(self, mw_id=None):
         """Return one or all maintenance windows."""
         if mw_id is None:
@@ -59,7 +59,7 @@ class Main(KytosNApp):
         except KeyError:
             raise NotFound(f'Maintenance with id {mw_id} not found')
 
-    @rest('/', methods=['POST'])
+    @rest('/v1', methods=['POST'])
     def create_mw(self):
         """Create a new maintenance window."""
         now = datetime.datetime.now(pytz.utc)
@@ -80,7 +80,7 @@ class Main(KytosNApp):
         self.maintenances[maintenance.id] = maintenance
         return jsonify({'mw_id': maintenance.id}), 201
 
-    @rest('/<mw_id>', methods=['PATCH'])
+    @rest('/v1/<mw_id>', methods=['PATCH'])
     def update_mw(self, mw_id):
         """Update a maintenance window."""
         data = request.get_json()
@@ -100,7 +100,7 @@ class Main(KytosNApp):
         self.scheduler.add(maintenance)
         return jsonify({'response': f'Maintenance {mw_id} updated'}), 200
 
-    @rest('/<mw_id>', methods=['DELETE'])
+    @rest('/v1/<mw_id>', methods=['DELETE'])
     def remove_mw(self, mw_id):
         """Delete a maintenance window."""
         try:
@@ -114,7 +114,7 @@ class Main(KytosNApp):
         return jsonify({'response': f'Maintenance with id {mw_id} '
                                     f'successfully removed'}), 200
 
-    @rest('/<mw_id>/end', methods=['PATCH'])
+    @rest('/v1/<mw_id>/end', methods=['PATCH'])
     def end_mw(self, mw_id):
         """Finish a maintenance window right now."""
         try:
@@ -133,7 +133,7 @@ class Main(KytosNApp):
         return jsonify({'response': f'Maintenance window {mw_id} '
                                     f'finished.'}), 200
 
-    @rest('/<mw_id>/extend', methods=['PATCH'])
+    @rest('/v1/<mw_id>/extend', methods=['PATCH'])
     def extend_mw(self, mw_id):
         """Extend a running maintenance window."""
         data = request.get_json()

--- a/openapi.yml
+++ b/openapi.yml
@@ -18,7 +18,7 @@ tags:
   - name: Update
   - name: Delete
 paths:
-  '/maintenance':
+  '/maintenance/v1':
     get:
       tags:
         - List
@@ -71,7 +71,7 @@ paths:
                 properties:
                   mw_id:
                     type: string
-  '/maintenance/{mw_id}':
+  '/maintenance/v1/{mw_id}':
     get:
       tags:
         - List
@@ -137,7 +137,7 @@ paths:
           description: Invalid JSON.
         '404':
           description: Maintenance window not found.
-  '/maintenance/{mw_id}/end':
+  '/maintenance/v1/{mw_id}/end':
     patch:
       tags:
         - Update
@@ -158,7 +158,7 @@ paths:
           description: Maintenance window not found.
         '415':
           description: No JSON in request.
-  '/maintenance/{mw_id}/extend':
+  '/maintenance/v1/{mw_id}/extend':
     patch:
       tags:
         - Update
@@ -196,7 +196,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '415':
           $ref: '#/components/responses/UnsupportedMediaType'
-  '/maintenance/report':
+  '/maintenance/v1/report':
     post:
       tags:
         - List

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -23,7 +23,7 @@ class TestMain(TestCase):
     def setUp(self):
         """Initialize before tests are executed."""
         self.server_name_url = \
-            'http://localhost:8181/api/kytos/maintenance'
+            'http://localhost:8181/api/kytos/maintenance/v1'
         self.controller = get_controller_mock()
         self.napp = Main(self.controller)
         self.api = self.get_app_test_client(self.napp)

--- a/ui/k-info-panel/edit_window.kytos
+++ b/ui/k-info-panel/edit_window.kytos
@@ -182,7 +182,7 @@
 
                 // Update the maitenance window with the new values.
                 var request = $.ajax({
-                    url: this.$kytos_server_api + "kytos/maintenance/" + _this.window_data.Id,
+                    url: this.$kytos_server_api + "kytos/maintenance/v1/" + _this.window_data.Id,
                     type: "PATCH",
                     data: JSON.stringify({
                         "id": _this.window_data.Id,
@@ -250,7 +250,7 @@
 
                 // Request the window data from the API.
                 var request = $.ajax({
-                    url: this.$kytos_server_api + "kytos/maintenance/" + id,
+                    url: this.$kytos_server_api + "kytos/maintenance/v1/" + id,
                     type: "GET",
                     dataType: "json",
                     contentType: "application/json"
@@ -366,7 +366,7 @@
 
                 // Request a deletion of the given window from the API.
                 var request = $.ajax({
-                    url: this.$kytos_server_api + "kytos/maintenance/" + _this.window_data.Id,
+                    url: this.$kytos_server_api + "kytos/maintenance/v1/" + _this.window_data.Id,
                     type:"DELETE"
                 });
                 request.done(function(data) {
@@ -609,7 +609,7 @@
 
                 // Call the Maintenace API to finish the maintenance window.
                 var request = $.ajax({
-                    url: this.$kytos_server_api + "kytos/maintenance/" + _this.window_data.Id + "/end",
+                    url: this.$kytos_server_api + "kytos/maintenance/v1/" + _this.window_data.Id + "/end",
                     type: "PATCH",
                     dataType: "json",
                     contentType: "application/json"
@@ -648,7 +648,7 @@
                 _this = this
                 // Call the Maintenace API to extend the maintenance window.
                 var request = $.ajax({
-                    url: this.$kytos_server_api + "kytos/maintenance/" + _this.window_data.Id + "/extend",
+                    url: this.$kytos_server_api + "kytos/maintenance/v1/" + _this.window_data.Id + "/extend",
                     type: "PATCH",
                     dataType: "json",
                     contentType: "application/json",

--- a/ui/k-info-panel/list_maintenance.kytos
+++ b/ui/k-info-panel/list_maintenance.kytos
@@ -89,7 +89,7 @@
         this.loading = true
 
         var request = $.ajax({
-            url: this.$kytos_server_api + "kytos/maintenance",
+            url: this.$kytos_server_api + "kytos/maintenance/v1",
             type: "GET",
             dataType: "json",
             contentType: "application/json"

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -73,7 +73,7 @@
                                           "end": self.end,
                                           "items": self.merged_list,         
                     }),
-                    url:this.$kytos_server_api + "kytos/maintenance",
+                    url:this.$kytos_server_api + "kytos/maintenance/v1",
                 });
 
                 request.done(function() {


### PR DESCRIPTION
Resolves #32 . Prepends all endpoints of the maintenance napp with `/v1` to indicate a version number. Also updates the UI to use the renamed endpoints.