### PR TITLE
release: bumped 2023.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,9 +37,6 @@ Fixed
 - Fixed error 500 when user attempts to add maintenance window with duplicate IDs
 - Fixed handling of all device types to properly express all affected devices.
 
-Security
-========
-
 Changed
 =======
 - Maintenance start and end no longer produce ``kytos/maintenance.*`` events, and instead produce ``topology.interruption.[start|end]`` events to work with blueprint EP0037

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,13 +8,28 @@ All notable changes to the Maintenance NApp will be documented in this file.
 
 Added
 =====
-- Added ``status_func`` and ``status_reason_func`` for maintenance windows.
 
 Deprecated
 ==========
 
 Removed
 =======
+
+Fixed
+=====
+
+Security
+========
+
+Changed
+=======
+
+[2023.1.0] - 2023-06-26
+***********************
+
+Added
+=====
+- Added ``status_func`` and ``status_reason_func`` for maintenance windows.
 
 Fixed
 =====

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "maintenance",
   "description": "This NApp creates maintenance windows, allowing the maintenance of network devices (switch, link, and interface) without receiving alerts.",
-  "version": "2022.3.1",
+  "version": "2023.1.0",
   "napp_dependencies": [],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
Closes #77

### Summary

- Bumped `2023.1.0` and updated changelog.

### Local Tests

Not needed

### End-to-End Tests

Done with #78, see that for latest results