### PR TITLE
release: bumped 2024.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,12 @@ All notable changes to the Maintenance NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.0] - 2024-07-23
+***********************
+
 Changed
 =======
 - Updated python environment installation from 3.9 to 3.11
-- Updated test dependencies
 - Upgraded UI framework to Vue3
 
 [2023.2.0] - 2024-02-16

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "maintenance",
   "description": "This NApp creates maintenance windows, allowing the maintenance of network devices (switch, link, and interface) without receiving alerts.",
-  "version": "2023.2.0",
+  "version": "2024.1.0",
   "napp_dependencies": [],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
### Summary

release: bumped 2024.1.0

### Local Tests

N/A

### End-to-End Tests

e2e nightly tests are passing. N/A for this PR.
