### PR TITLE
Maintenance Modal Utilizes New Modal Component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the Maintenance NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Changed
+=======
+- The maintenance modal now uses the modal component
+
 [2024.1.1] - 2024-09-09
 ***********************
 

--- a/ui/k-info-panel/edit_window.kytos
+++ b/ui/k-info-panel/edit_window.kytos
@@ -43,30 +43,12 @@
                         </template>
                     </tr>
                 </table>
-                <template v-if="delete_window">
-                    <div class="modal-mask">
-                        <div class="modal-wrapper">
-                            <div class="modal-container">
-                                <div class="modal-header">
-                                    <slot name="header"></slot>
-                                </div>
-                                <div class="modal-body">
-                                    <slot name="body">
-                                        Delete Maintenace Window? 
-                                    </slot>
-                                </div>
-                                <div class="modal-footer">
-                                    <slot name="footer">
-                                        <k-button tooltip="Cancel the deletion of the Maintenace Window" title="Cancel" @click="cancelDeleteWindow">
-                                        </k-button>
-                                        <k-button id="modalOK" tooltip="Delete the Maintenace Window" title="Delete" @click="okDeleteWindow">
-                                        </k-button>
-                                    </slot>
-                                </div>
-                            </div>
-                        </div>
-                        </div>
-                </template>
+                <k-modal
+                    message="Delete Maintenace Window?"
+                    button-title="Delete"
+                    :action="deleteMaintenanceWindow"
+                    v-model:show-modal="delete_window">
+                </k-modal>
             </div>
         </div>
         <div class="window-buttons">
@@ -211,20 +193,6 @@
             */
             showDeleteWindow: function() {
                 this.delete_window = true
-            },
-            /*
-                Hides the modal delete window option.
-            */
-            cancelDeleteWindow: function() {
-                this.delete_window = false
-            },
-            /*
-                Hides the modal delete window options and
-                deletes the current maintenance window.
-            */
-            okDeleteWindow: function() {
-                this.delete_window = false
-                this.deleteMaintenanceWindow()
             },
             /*
                 Loads the given maintenance window into a table.
@@ -756,58 +724,6 @@
     }
     .window-editable:hover {
         background: #919191;
-    }
-
-    /* Delete confirmation window */
-    .modal-mask {
-        position: fixed;
-        z-index: 9998;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: rgba(0, 0, 0, 0.5);
-        display: table;
-        transition: opacity 0.3s ease;
-    }
-    .modal-wrapper {
-        display: table-cell;
-        vertical-align: middle;
-    }
-    .modal-container {
-        width: 300px;
-        margin: 0px auto;
-        padding: 10px 10px 10px 20px;;
-        background-color: #e8e8e8;
-        border-radius: 2px;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33);
-        transition: all 0.3s ease;
-        font-family: Helvetica, Arial, sans-serif;
-    }
-    .modal-body {
-        margin: 20px 0;
-    }
-    .modal-default-button {
-        float: right;
-    }
-    .modal-enter {
-        opacity: 0;
-    }
-    .modal-leave-active {
-        opacity: 0;
-    }
-    .modal-enter .modal-container,
-    .modal-leave-active .modal-container {
-        -webkit-transform: scale(1.1);
-        transform: scale(1.1);
-    }
-    .modal-footer {
-        justify-content: end; 
-        display: flex;
-    }
-    #modalOK {
-        color: #ffc5c5;
-        background: #be0000;
     }
 </style>
 


### PR DESCRIPTION
Closes #N/A

### Summary

A new modal component was added to the UI repository. This pull request makes it so that the maintenance UI now utilizes the new modal component.

### Local Tests

A maintenance window was created and it was deleted utilizing the modal.

### Associated Pull Requests

#### Parent

Description - UI repo in which the new modal component was implemented

- https://github.com/kytos-ng/ui/pull/80

### Additional Issues

Buttons were utilizing `:on_click=""` which did not seem to function, so they were replaced with `@click=""`.
