### PR TITLE
UI Button Fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the Maintenance NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.1] - 2024-09-09
+***********************
+
+Fixed
+=====
+- Fixed maintenance ``edit_windows.kytos`` buttons 
+
 [2024.1.0] - 2024-07-23
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "maintenance",
   "description": "This NApp creates maintenance windows, allowing the maintenance of network devices (switch, link, and interface) without receiving alerts.",
-  "version": "2024.1.0",
+  "version": "2024.1.1",
   "napp_dependencies": [],
   "license": "MIT",
   "tags": [],

--- a/ui/k-info-panel/edit_window.kytos
+++ b/ui/k-info-panel/edit_window.kytos
@@ -3,15 +3,15 @@
         <div class="window-buttons">
             <div class="window-buttons-left">
                 <div class="window-back-button">
-                    <k-button tooltip="List Maintenance Windows" title="< Back to list" :on_click="showInfoPanel"></k-button>
+                    <k-button tooltip="List Maintenance Windows" title="< Back to list" @click="showInfoPanel"></k-button>
                 </div>
             </div>
             <div class="window-buttons-right">
                 <div class="window-save-button">
-                    <k-button tooltip="Save Maintenace Window" title="Save Window" :on_click="saveWindow"></k-button>
+                    <k-button tooltip="Save Maintenace Window" title="Save Window" @click="saveWindow"></k-button>
                 </div>
                 <div class="window-delete-button">
-                    <k-button tooltip="Delete Maintenace Window" title="Delete Window" :on_click="showDeleteWindow"></k-button>
+                    <k-button tooltip="Delete Maintenace Window" title="Delete Window" @click="showDeleteWindow"></k-button>
                 </div>
             </div>
         </div>
@@ -72,10 +72,10 @@
         <div class="window-buttons">
             <div class="window-buttons-bottom">
                 <div class="window-finish-button">
-                    <k-button tooltip="Finish Maintenance Window" title="Finish Window" :on_click="finishMaintenanceWindow"></k-button> 
+                    <k-button tooltip="Finish Maintenance Window" title="Finish Window" @click="finishMaintenanceWindow"></k-button> 
                 </div>
                 <div class = "window-extend-button">
-                    <k-button title="Extend Window" :on_click="extendWindow"></k-button>
+                    <k-button title="Extend Window" @click="extendWindow"></k-button>
                 </div>
                 <div class = "minute-input-field">
                     <k-input placeholder = "Enter minutes (click extend)" v-model:value ="minutes"></k-input>  


### PR DESCRIPTION
Closes #93 

### Summary

Some buttons were using the old `on_click `instead of the new `@click`. These buttons were updated accordingly to use the new `@click`. 

### Local Tests

The buttons were pressed and they functioned as should.