### PR TITLE
Removed this.$set()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changed
 =======
 - UI: The maintenance modal now uses the modal component
 - UI: changed variable name which was the reserved keyword interface to k_interface
+- UI: Removed the use of this.$set() since it was deprecated
 
 [2024.1.1] - 2024-09-09
 ***********************

--- a/ui/k-info-panel/list_maintenance.kytos
+++ b/ui/k-info-panel/list_maintenance.kytos
@@ -66,7 +66,7 @@
         if(new_sort == this.current_sort) {
             // Switch the sorting order.
             let sort_dir = (this.current_sort_dir[new_sort] === 'asc') ? 'desc' : 'asc'
-            this.$set(this.current_sort_dir, new_sort, sort_dir)
+            this.current_sort_dir[new_sort] = sort_dir;
         }
         this.current_sort = new_sort
      },


### PR DESCRIPTION
Closes #108

### Summary

this.$set() was used in vue js 2 to add reactive properties to objects. Within vue js 3 this is no longer needed since properties are made reactive by default, so it was removed.

### Local Tests

After removing the use of set I no longer got a warning for the using it.

### End-to-End Tests
