### PR TITLE
fix: DB controller now retries for `ExecutionTimeout` and `ConnectionFailure` instead of just `AutoReconnect`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Changed
 - UI: changed variable name which was the reserved keyword interface to k_interface
 - UI: Removed the use of this.$set() since it was deprecated
 
+Fixed
+=====
+- DB controller now retries for ``ExecutionTimeout`` and ``ConnectionFailure`` instead of just ``AutoReconnect``
+
 [2024.1.1] - 2024-09-09
 ***********************
 

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from bson.codec_options import CodecOptions
 import pymongo
-from pymongo.errors import AutoReconnect
+from pymongo.errors import ConnectionFailure, ExecutionTimeout
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
 from kytos.core import log
@@ -32,7 +32,7 @@ from napps.kytos.maintenance.models import (
         max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", 1)),
     ),
     before_sleep=before_sleep,
-    retry=retry_if_exception_type((AutoReconnect,)),
+    retry=retry_if_exception_type((ConnectionFailure, ExecutionTimeout)),
 )
 class MaintenanceController:
     """MaintenanceController."""


### PR DESCRIPTION
Closes https://github.com/kytos-ng/kytos/issues/535

### Summary

- See updated changelog file 
- Index creation timeout didn't get ajusted since the default is plenty when its first created

### Local Tests

Local tests were done with https://github.com/kytos-ng/kytos/pull/539 

### End-to-End Tests

E2e tests were done with https://github.com/kytos-ng/kytos/pull/539 