### PR TITLE
release 2024.1.2: DB controller now retries for `ExecutionTimeout` and `ConnectionFailure` instead of just `AutoReconnect`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the Maintenance NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.2] - 2025-03-03
+************************
+
+Fixed
+=====
+- DB controller now retries for ``ExecutionTimeout`` and ``ConnectionFailure`` instead of just ``AutoReconnect``
+
 [2024.1.1] - 2024-09-09
 ***********************
 

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from bson.codec_options import CodecOptions
 import pymongo
-from pymongo.errors import AutoReconnect
+from pymongo.errors import ConnectionFailure, ExecutionTimeout
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
 from kytos.core import log
@@ -32,7 +32,7 @@ from napps.kytos.maintenance.models import (
         max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", 1)),
     ),
     before_sleep=before_sleep,
-    retry=retry_if_exception_type((AutoReconnect,)),
+    retry=retry_if_exception_type((ConnectionFailure, ExecutionTimeout)),
 )
 class MaintenanceController:
     """MaintenanceController."""

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "maintenance",
   "description": "This NApp creates maintenance windows, allowing the maintenance of network devices (switch, link, and interface) without receiving alerts.",
-  "version": "2024.1.1",
+  "version": "2024.1.2",
   "napp_dependencies": [],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
Closes https://github.com/kytos-ng/kytos/issues/538

- See updated changelog file 
- Index creation timeout didn't get adjusted since the default is plenty when its first created

### Local Tests

Local tests were done with https://github.com/kytos-ng/kytos/pull/541

### Unit tests

```
coverage: OK ✔ in 34.89 seconds
lint: recreate env because env type changed from {'name': 'coverage', 'type': 'VirtualEnvRunner'} to {'name': 'lint', 'type': 'VirtualEnvRunner'}
lint: remove tox env folder /home/viniarck/repos/ky20241/maintenance/.tox/py311
lint: install_deps> python -I -m pip install -r requirements/dev.in
lint: commands[0]> python3 setup.py lint
running lint
Yala is running. It may take several seconds...
INFO: Finished pycodestyle
INFO: Finished isort
INFO: Finished black
INFO: Finished pylint
:) No issues found.
No linter error found.
  coverage: OK (34.89=setup[30.23]+cmd[4.66] seconds)
  lint: OK (35.64=setup[29.28]+cmd[6.36] seconds)
  congratulations :) (70.56 seconds)

```

### End-to-End Tests

E2e tests were done with https://github.com/kytos-ng/kytos/pull/541 