### PR TITLE
Made maintenance window list CSS important so 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Changed
 =======
 - Internal refactoring updating UI components to use ``pinia``
 
+Fixed
+=======
+- Fixed overridden CSS from the maintenance window list, which affected width
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/ui/k-info-panel/edit_window.kytos
+++ b/ui/k-info-panel/edit_window.kytos
@@ -639,7 +639,7 @@
 
 <style type="text/css">
     .maintenance-window-k-info-panel {
-        width: calc(100% - 300px);
+        width: calc(100% - 300px) !important;
     }
 
     .maintenance-window-container .window-buttons {

--- a/ui/k-info-panel/list_maintenance.kytos
+++ b/ui/k-info-panel/list_maintenance.kytos
@@ -295,7 +295,7 @@
 
 <style type="text/css">
     .maintenance-k-info-panel {
-        width: calc(100% - 300px);
+        width: calc(100% - 300px) !important;
     }
 
     .empty-window-list {


### PR DESCRIPTION
Closes kytos-ng/UI#233

### Summary

There was CSS from the main UI repo overriding the CSS from the maintenance window list, which affected its width. Because of this, I just marked the CSS as important so it could not be overridden.

### Local Tests

The window width was back to normal.
<img width="1918" height="1002" alt="image" src="https://github.com/user-attachments/assets/5b2d6682-6a68-4e62-ad78-93d5a7945ae0" />



