### PR TITLE
release 2025.1.1: fixed overridden CSS from the maintenance window list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the Maintenance NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.1.1] - 2025-08-08
+***********************
+
+Fixed
+=====
+- UI: Fixed overridden CSS from the maintenance window list, which affected width
+
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "maintenance",
   "description": "This NApp creates maintenance windows, allowing the maintenance of network devices (switch, link, and interface) without receiving alerts.",
-  "version": "2025.1.0",
+  "version": "2025.1.1",
   "napp_dependencies": [],
   "license": "MIT",
   "tags": [],

--- a/ui/k-info-panel/edit_window.kytos
+++ b/ui/k-info-panel/edit_window.kytos
@@ -639,7 +639,7 @@
 
 <style type="text/css">
     .maintenance-window-k-info-panel {
-        width: calc(100% - 300px);
+        width: calc(100% - 300px) !important;
     }
 
     .maintenance-window-container .window-buttons {

--- a/ui/k-info-panel/list_maintenance.kytos
+++ b/ui/k-info-panel/list_maintenance.kytos
@@ -295,7 +295,7 @@
 
 <style type="text/css">
     .maintenance-k-info-panel {
-        width: calc(100% - 300px);
+        width: calc(100% - 300px) !important;
     }
 
     .empty-window-list {


### PR DESCRIPTION
Closes #124 

Backported from @HeriLFIU PR #122 

### Summary

See updated changelog file 

### Local Tests

Tested it with `kytosd` 2025.1 release:

Before:
<img width="1920" height="885" alt="20250808_140653" src="https://github.com/user-attachments/assets/4bc18e6a-9ad6-4895-b9ca-8959a7322a2a" />

After:
<img width="1920" height="885" alt="20250808_140729" src="https://github.com/user-attachments/assets/922d0713-882a-48b6-baac-88184dafc714" />


### End-to-End Tests

N/A for UI
