### PR TITLE
Limited force option to check components

### DIFF
--- a/managers/scheduler.py
+++ b/managers/scheduler.py
@@ -121,11 +121,9 @@ class MaintenanceScheduler:
 
     def add(self, window: MaintenanceWindow, force=False):
         """Add jobs to start and end a maintenance window."""
-
-        if force is False:
-            overlapping_windows = self.db_controller.check_overlap(window)
-            if overlapping_windows:
-                raise OverlapError(window, overlapping_windows)
+        overlapping_windows = self.db_controller.check_overlap(window, force)
+        if overlapping_windows:
+            raise OverlapError(window, overlapping_windows)
 
         # Add window to DB
         self.db_controller.insert_window(window)

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -100,3 +100,21 @@ class TestMaintenanceController:
         expected = MaintenanceWindows.model_construct(root = [self.window])
         result = self.controller.get_windows()
         assert result == expected
+
+    def test_check_overlap(self):
+        """Test check_overlap method."""
+        aux_window = {'description': 'My description',
+                'start': self.now + timedelta(hours=1),
+                'end': self.now + timedelta(hours=2),
+                'switches': ['00:00:00:00:00:00:00:01'],
+                'interfaces': ['00:00:00:00:00:00:00:02:1']}
+        obj_mw = MaintenanceWindow.model_validate(aux_window)
+        self.controller.windows.find.return_value = []
+        self.controller.check_overlap(obj_mw, True)
+        query = self.controller.windows.find.call_args[0][0]
+        assert len(query["$and"]) == 3
+        assert "$or" in query["$and"][2]
+
+        self.controller.check_overlap(obj_mw, False)
+        query = self.controller.windows.find.call_args[0][0]
+        assert len(query["$and"]) == 2


### PR DESCRIPTION
Closes #123

### Summary

Limited force option to check for components overlap in time sections.=.

### Local Tests
Tested with pull requests:
Base NW to test against:
```
{
  "description": "MW control",
  "start": "2027-10-08T16:42:00+0000",
  "end": "2027-10-08T16:42:30+0000",
  "switches": [
    "00:00:00:00:00:00:00:02"
  ],
  "interfaces": [
    "00:00:00:00:00:00:00:02:1",
    "00:00:00:00:00:00:00:02:2"
  ]
}
```

`force=False` with new switch (should FAIL):
```
{
  "description": "No force",
  "start": "2027-10-08T16:42:10+0000",
  "end": "2027-10-08T16:42:20+0000",
  "switches": [
    "00:00:00:00:00:00:00:01"
  ]
}
```

`force=True` with new switch (should PASS):
```
{
  "description": "Forced MW",
  "start": "2027-10-08T16:42:10+0000",
  "end": "2027-10-08T16:42:20+0000",
  "switches": [
    "00:00:00:00:00:00:00:01"
  ],
  "force": true
}
```

`force=True` with already used interface `00:00:00:00:00:00:00:02:2` (should FAIL, because it is already part of the first MW and it interferes with its separated time):
```
{
  "description": "Forced MW2",
  "start": "2027-10-08T16:42:10+0000",
  "end": "2027-10-08T16:42:20+0000",
  "interfaces": [
    "00:00:00:00:00:00:00:02:3",
    "00:00:00:00:00:00:00:02:2"
  ],
  "force": true
}
```

`force=True` and `00:00:00:00:00:00:00:02:2` removed (should PASS)
```
{
  "description": "My description2",
  "start": "2027-10-08T16:42:10+0000",
  "end": "2027-10-08T16:42:20+0000",
  "interfaces": [
    "00:00:00:00:00:00:00:02:3"
  ],
  "force": true
}
```

### End-to-End Tests
Running
