### PR TITLE
Separated assets into two columns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Changed
 - Force option will not ignore time anymore. Instead it will check for time conflicts between assets (switches, interfaces, links).
 - MWs can now be created without an ``end``, meaning they will have no end time (actual value is ``9999-12-31T23:59:59.999Z`` which is unreachable). If such MW starts running, it can only be stopped by request and not by updating the MW.
 - UI: A modal will appear to confirm if a MW will be created without ``End Time``.
+- UI: Maintenance Window Detail window now separates assets (switches, interfaces, links) between ``Selected`` and ``Available`` assets. When first loading the window, the ``Selected`` column will have all the assets that the MW will cover. ``Available`` column will present all assets not affected by the MW.
+- UI: Added buttons under ``Selected`` and ``Available`` columns to move assets from column to the other. The assets moved will be the ones selected from the boxes above each button to the other column.
+- UI: When pressing ``Save Window``, all the assets under ``Selected`` column will be patched/added to the MW if any were added to this column after opening the details window.
 
 Fixed
 =======

--- a/ui/k-info-panel/edit_window.kytos
+++ b/ui/k-info-panel/edit_window.kytos
@@ -332,12 +332,6 @@
                 var _this = this
                 var content_id = this.content.id
                 // Asynchronously get the links, switches, and interfaces from the topology API.
-                //Promise.all([this.loadLinksForEditing(), this.loadSwitchesForEditing(), this.loadInterfacesForEditing()])
-                //.then(function() {
-                //    // Once the three things are done, continue loading.
-                //    _this.loadMaintenanceWindow(content_id)
-                //})
-
                 Promise.all([_this.loadMaintenanceWindow(content_id)])
                 .then(function() {
                     _this.loadLinksForEditing()
@@ -736,6 +730,9 @@
         padding-bottom: 8px;
         text-align: left;
         font-size: 0.9em;
+    }
+    .maintenance-window-table table td {
+        font-size: 1.1em;
     }
 
     .editable-false {

--- a/ui/k-info-panel/edit_window.kytos
+++ b/ui/k-info-panel/edit_window.kytos
@@ -38,27 +38,51 @@
                                         <tr>
                                             <td>
                                                 <div :class="'editable-' + property_editable['Links']">
-                                                    <k-select icon="link" title="Links" :options="sele_link_options" v-model:value="sele_chosen_links"></k-select>
+                                                    <k-select icon="link" title="Links"
+                                                        :options="sele_link_options"
+                                                        v-model:value="sele_chosen_links"
+                                                        :key="componentKey">
+                                                    </k-select>
                                                 </div>
                                                 <div :class="'editable-' + property_editable['Switches']">
-                                                    <k-select icon="link" title="Switches" :options="sele_switch_options" v-model:value="sele_chosen_switches"></k-select>
+                                                    <k-select icon="link" title="Switches"
+                                                        :options="sele_switch_options"
+                                                        v-model:value="sele_chosen_switches"
+                                                        :key="componentKey">
+                                                    </k-select>
                                                 </div>
                                                 <div :class="'editable-' + property_editable['Interfaces']">
-                                                    <k-select  icon="link" title="Interfaces" :options="sele_interface_options" v-model:value="sele_chosen_interfaces"></k-select>
+                                                    <k-select  icon="link" title="Interfaces"
+                                                        :options="sele_interface_options"
+                                                        v-model:value="sele_chosen_interfaces"
+                                                        :key="componentKey">
+                                                    </k-select>
                                                 </div>
-                                                <k-button title="Remove Components"></k-button>
+                                                <k-button style="display: block; margin: auto;" title="Move to Available ->" @click="moveToAvailableBT"></k-button>
                                             </td>
                                             <td>
                                                 <div :class="'editable-' + property_editable['Links']">
-                                                    <k-select icon="link" title="Links" :options="aval_link_options" v-model:value="aval_chosen_links"></k-select>
+                                                    <k-select icon="link" title="Links"
+                                                        :options="aval_link_options"
+                                                        v-model:value="aval_chosen_links"
+                                                        :key="componentKey">
+                                                    </k-select>
                                                 </div>
                                                 <div :class="'editable-' + property_editable['Switches']">
-                                                    <k-select icon="link" title="Switches" :options="aval_switch_options" v-model:value="aval_chosen_switches"></k-select>
+                                                    <k-select icon="link" title="Switches"
+                                                        :options="aval_switch_options"
+                                                        v-model:value="aval_chosen_switches"
+                                                        :key="componentKey">
+                                                    </k-select>
                                                 </div>
                                                 <div :class="'editable-' + property_editable['Interfaces']">
-                                                    <k-select  icon="link" title="Interfaces" :options="aval_interface_options" v-model:value="aval_chosen_interfaces"></k-select>
+                                                    <k-select  icon="link" title="Interfaces"
+                                                        :options="aval_interface_options"
+                                                        v-model:value="aval_chosen_interfaces"
+                                                        :key="componentKey">
+                                                    </k-select>
                                                 </div>
-                                                <k-button title="Add Components" @click="finishMaintenanceWindow"></k-button>
+                                                <k-button style="display: block; margin: auto;" title="<- Move to Selected" @click="moveToSelectedBT"></k-button>
                                             </td>
                                         </tr>
                                     </table>
@@ -130,6 +154,7 @@
                 aval_chosen_links: [],
                 aval_chosen_switches: [],
                 aval_chosen_interfaces: [],
+                componentKey: "",
             }
         },
         methods: {
@@ -620,21 +645,51 @@
                 })           
             },
             /*
+                Updates two Array of options(value, description) from an Array of values.
+                 addToOptions, gets options added from removeFromOptions which "value" are in selectedOptions
+                 removeFromOptions, gets options searched, options which "value" are not in selectedOptions are saved
+                 
+                Return any saved options from searching removeFromOptions
+            */
+            updateOptions: function(addToOptions, removeFromOptions, selectedOptions) {
+                let selected_set = new Set(selectedOptions)
+
+                let leftover_options = removeFromOptions.filter((option) => {
+                    if (selected_set.has(option.value)) {
+                        addToOptions.push(option)
+                        return false
+                    }
+                    return true
+                })
+                return leftover_options
+            },
+            /*
                 Button: Move components inside select boxes under "Selected" section to "Available" section
             */
-            removeComponentsBT: function() {
-
+            moveToSelectedBT: function() {
+                this.aval_link_options = this.updateOptions(
+                    this.sele_link_options, this.aval_link_options, this.aval_chosen_links
+                )
+                this.aval_switch_options = this.updateOptions(
+                    this.sele_switch_options, this.aval_switch_options, this.aval_chosen_switches
+                )
+                this.aval_interface_options = this.updateOptions(
+                    this.sele_interface_options, this.aval_interface_options, this.aval_chosen_interfaces
+                )
             },
             /*
                 Button: Move components inside select boxes under "Available" section to "Selected" section
             */
-            addComponentsBT: function() {
-
-            },
-            clickME: function() {
-                console.log("LINKS -> ", this.sele_link_options)
-                console.log("SWITCHES -> ", this.sele_switch_options)
-                console.log("INTERFACES -> ", this.sele_interface_options)
+            moveToAvailableBT: function() {
+                this.sele_link_options = this.updateOptions(
+                    this.aval_link_options, this.sele_link_options, this.sele_chosen_links
+                )
+                this.sele_switch_options = this.updateOptions(
+                    this.aval_switch_options, this.sele_switch_options, this.sele_chosen_switches
+                )
+                this.sele_interface_options = this.updateOptions(
+                    this.aval_interface_options, this.sele_interface_options, this.sele_chosen_interfaces
+                )
             },
         },
         mounted() {

--- a/ui/k-info-panel/edit_window.kytos
+++ b/ui/k-info-panel/edit_window.kytos
@@ -30,15 +30,38 @@
                         <template v-else-if="property == 'Links'" class="window-table-items">
                                 <th>Items</th>
                                 <td>
-                                    <div :class="'editable-' + property_editable['Links']">
-                                        <k-select icon="link" title="Links" :options="links_options" v-model:value="chosen_links"></k-select>
-                                    </div>
-                                    <div :class="'editable-' + property_editable['Switches']">
-                                        <k-select icon="link" title="Switches" :options="switches_options" v-model:value="chosen_switches"></k-select>
-                                    </div>
-                                    <div :class="'editable-' + property_editable['Interfaces']">
-                                        <k-select  icon="link" title="Interfaces" :options="interfaces_options" v-model:value="chosen_interfaces"></k-select>
-                                    </div>
+                                    <table>
+                                        <tr>
+                                            <th style="text-align: center">Selected</th>
+                                            <th style="text-align: center">Available</th>
+                                        </tr>
+                                        <tr>
+                                            <td>
+                                                <div :class="'editable-' + property_editable['Links']">
+                                                    <k-select icon="link" title="Links" :options="sele_link_options" v-model:value="sele_chosen_links"></k-select>
+                                                </div>
+                                                <div :class="'editable-' + property_editable['Switches']">
+                                                    <k-select icon="link" title="Switches" :options="sele_switch_options" v-model:value="sele_chosen_switches"></k-select>
+                                                </div>
+                                                <div :class="'editable-' + property_editable['Interfaces']">
+                                                    <k-select  icon="link" title="Interfaces" :options="sele_interface_options" v-model:value="sele_chosen_interfaces"></k-select>
+                                                </div>
+                                                <k-button title="Remove Components"></k-button>
+                                            </td>
+                                            <td>
+                                                <div :class="'editable-' + property_editable['Links']">
+                                                    <k-select icon="link" title="Links" :options="aval_link_options" v-model:value="aval_chosen_links"></k-select>
+                                                </div>
+                                                <div :class="'editable-' + property_editable['Switches']">
+                                                    <k-select icon="link" title="Switches" :options="aval_switch_options" v-model:value="aval_chosen_switches"></k-select>
+                                                </div>
+                                                <div :class="'editable-' + property_editable['Interfaces']">
+                                                    <k-select  icon="link" title="Interfaces" :options="aval_interface_options" v-model:value="aval_chosen_interfaces"></k-select>
+                                                </div>
+                                                <k-button title="Add Components" @click="finishMaintenanceWindow"></k-button>
+                                            </td>
+                                        </tr>
+                                    </table>
                                 </td>
                         </template>
                     </tr>
@@ -58,6 +81,7 @@
                 </div>
                 <div class = "window-extend-button">
                     <k-button title="Extend Window" @click="extendWindow"></k-button>
+                    <k-button title="CLICK ON ME" @click="clickME"></k-button>
                 </div>
                 <div class = "minute-input-field">
                     <k-input placeholder = "Enter minutes (click extend)" v-model:value ="minutes"></k-input>  
@@ -88,6 +112,24 @@
                 delete_window: false,
                 display: true,
                 minutes: "",
+                mw_links_set: new Set(),
+                mw_switches_set: new Set(),
+                mw_interfaces_set: new Set(),
+                topo_links: [], 
+                topo_switches: [],
+                topo_interfaces: [],
+                sele_link_options: [],
+                sele_switch_options: [],
+                sele_interface_options: [],
+                sele_chosen_links: [],
+                sele_chosen_switches: [],
+                sele_chosen_interfaces: [],
+                aval_link_options: [],
+                aval_switch_options: [],
+                aval_interface_options: [],
+                aval_chosen_links: [],
+                aval_chosen_switches: [],
+                aval_chosen_interfaces: [],
             }
         },
         methods: {
@@ -144,12 +186,7 @@
                     // Otherwise, add the interface id to the list of links.
                     filteredInterfaces.push(item)
                 }
-
-                // Update the maitenance window with the new values.
-                var request = $.ajax({
-                    url: this.$kytos_server_api + "kytos/maintenance/v1/" + _this.window_data.Id,
-                    type: "PATCH",
-                    data: JSON.stringify({
+                console.log("BEING SENT -> ", {
                         "id": _this.window_data.Id,
                         "start": _this.window_data.Start,
                         "end": _this.window_data.End,
@@ -157,36 +194,49 @@
                         "links": filteredLinks,
                         "switches": filteredSwitches,
                         "interfaces": filteredInterfaces,
-                    }),
-                    dataType: "json",
-                    contentType: "application/json"
-                })
-                request.done( function(data) {
-                    let notification = {
-                        title: 'Window "' + _this.window_data.Id + '" updated.',
-                        description: ''
-                    }
-                    // Notify on success.
-                    _this.$kytos.eventBus.$emit("setNotification", notification)
-                    // Refresh the window.
-                    _this.resetItemSelection()
-                    _this.loadMaintenanceWindow(_this.window_data.Id)
-                })
-                request.fail(function(jqXHR, status, error ) {
-                    let error_message = JSON.parse(jqXHR.responseText)
-                    if (error_message.hasOwnProperty('response')) {
-                        error_message = error_message.response
-                    } else if (error_message.hasOwnProperty('description')) {
-                        error_message = error_message.description
-                    }
-
-                    let notification = {
-                        title: 'Updated Window failed.',
-                        description: 'Error updating window "' + _this.window_data.Id + '". ' + _this.capitalize(status) + ': ' +  error_message
-                    }
-                    // Notify on failure.
-                    _this.$kytos.eventBus.$emit("setNotification", notification)
-                })
+                    })
+                // Update the maitenance window with the new values.
+                //var request = $.ajax({
+                //    url: this.$kytos_server_api + "kytos/maintenance/v1/" + _this.window_data.Id,
+                //    type: "PATCH",
+                //    data: JSON.stringify({
+                //        "id": _this.window_data.Id,
+                //        "start": _this.window_data.Start,
+                //        "end": _this.window_data.End,
+                //        "description": _this.window_data.Description,
+                //        "links": filteredLinks,
+                //        "switches": filteredSwitches,
+                //        "interfaces": filteredInterfaces,
+                //    }),
+                //    dataType: "json",
+                //    contentType: "application/json"
+                //})
+                //request.done( function(data) {
+                //    let notification = {
+                //        title: 'Window "' + _this.window_data.Id + '" updated.',
+                //        description: ''
+                //    }
+                //    // Notify on success.
+                //    _this.$kytos.eventBus.$emit("setNotification", notification)
+                //    // Refresh the window.
+                //    _this.resetItemSelection()
+                //    _this.loadMaintenanceWindow(_this.window_data.Id)
+                //})
+                //request.fail(function(jqXHR, status, error ) {
+                //    let error_message = JSON.parse(jqXHR.responseText)
+                //    if (error_message.hasOwnProperty('response')) {
+                //        error_message = error_message.response
+                //    } else if (error_message.hasOwnProperty('description')) {
+                //        error_message = error_message.description
+                //    }
+                //
+                //    let notification = {
+                //        title: 'Updated Window failed.',
+                //        description: 'Error updating window "' + _this.window_data.Id + '". ' + _this.capitalize(status) + ': ' +  error_message
+                //    }
+                //    // Notify on failure.
+                //    _this.$kytos.eventBus.$emit("setNotification", notification)
+                //})
             },
             /*
                 Shows the modal delete window option.
@@ -201,19 +251,15 @@
                 var _this = this
 
                 // Request the window data from the API.
-                var request = $.ajax({
+                return $.ajax({
                     url: this.$kytos_server_api + "kytos/maintenance/v1/" + id,
                     type: "GET",
                     dataType: "json",
                     contentType: "application/json"
-                })
-                request.done( function(data) {
+                }).done( function(data) {
                     // Build the maintenance window to be displayed.
                     _this.buildMaintenanceWindow(data)
-                    // Determine what can be edited and what can not.
-                    _this.setEditable(data)
-                })
-                request.fail(function(jqXHR, status) {
+                }).fail(function(jqXHR, status) {
                     let notification = {
                         title: "Error Loading Maintenace Window.",
                         description: 'Error loading window "' + _this.window_data.id + '". ' + _this.capitalize(status) + ': ' +  JSON.parse(jqXHR.responseText).response
@@ -227,55 +273,10 @@
             */
             buildMaintenanceWindow: function(window) {
                 // Translate the window API status into its corresponding word.
+                this.mw_links_set = new Set(window.links)
+                this.mw_switches_set = new Set(window.switches)
+                this.mw_interfaces_set = new Set(window.interfaces)
                 let status = window.status
-
-                var auto_links = []
-                var auto_switches = []
-                var auto_interfaces = []
-                
-                // For every item in the list of items.
-                for(let i = 0; i < window.links.length; i++) {
-                    // LINK
-                    let link = window.links[i]
-
-                    // Checks that link is not in topology in case there were errors accessing topology
-                    // or a deletion of the link after the creation of the maintenance window.
-                    let linkInTopology = this.links_options.some(option => option.value == link)
-                    if(!linkInTopology) {
-                        // Add the link as an option even if it is not in topology.
-                        this.links_options.push({"value":link, "description":link})
-                    }
-                    // Add the link into the list of link auto-selection.
-                    auto_links.push(link)
-                }
-                for(let i = 0; i < window.switches.length; i++) {
-                    // SWITCH
-                    let switch_item = window.switches[i]
-
-                    // Checks that switch_item is not in topology in case there were errors accessing topology
-                    // or a deletion of the switch after the creation of the maintenance window.
-                    let switchInTopology = this.switches_options.some(option => option.value == switch_item)
-                    if(!switchInTopology) {
-                        // Add the switch as an option even if it is not in topology.
-                        this.switches_options.push({"value":switch_item, "description":switch_item})
-                    }
-                    // Add the switch into the list of switch auto-selection.
-                    auto_switches.push(switch_item)
-                }
-                for(let i = 0; i < window.interfaces.length; i++) {
-                    // INTERFACE
-                    let k_interface = window.interfaces[i]
-
-                    // Checks that interface is not in topology in case there were errors accessing topology
-                    // or a deletion of the interface after the creation of the maintenance window.
-                    let interfaceInTopology = this.interfaces_options.some(option => option.value == k_interface)
-                    if(!interfaceInTopology) {
-                        // Add the interface as an option even if it not in topology.
-                        this.interfaces_options.push({"value":k_interface, "description":k_interface})
-                    }
-                    // Add the interface into the list of interface auto-selection.
-                    auto_interfaces.push(k_interface)
-                }
 
                 // Build the columns to be displayed in the table.
                 let column = {
@@ -289,17 +290,6 @@
                     "Interfaces": "k-select",   // k-select
                 }
                 this.window_data = column
-
-                // Add the list of auto-selected links, switches, and interfaces 
-                // to the list of auto-selected items.
-                this.auto_items.push(auto_links)
-                this.auto_items.push(auto_switches)
-                this.auto_items.push(auto_interfaces)
-
-                // Call the auto-select items after the k-selects have loaded.
-                this.$nextTick(() => {
-                    this.autoSelectItems()
-                });
             },
             /*
                 Delete a maintenance window.
@@ -337,11 +327,19 @@
                 var _this = this
                 var content_id = this.content.id
                 // Asynchronously get the links, switches, and interfaces from the topology API.
-                Promise.all([this.loadLinksForEditing(), this.loadSwitchesForEditing(), this.loadInterfacesForEditing()])
+                //Promise.all([this.loadLinksForEditing(), this.loadSwitchesForEditing(), this.loadInterfacesForEditing()])
+                //.then(function() {
+                //    // Once the three things are done, continue loading.
+                //    _this.loadMaintenanceWindow(content_id)
+                //})
+
+                Promise.all([_this.loadMaintenanceWindow(content_id)])
                 .then(function() {
-                    // Once the three things are done, continue loading.
-                    _this.loadMaintenanceWindow(content_id)
+                    _this.loadLinksForEditing()
+                    _this.loadSwitchesForEditing()
+                    _this.loadInterfacesForEditing()
                 })
+                this.setEditable()
             },
             /*
                 Get the links from the topology API.
@@ -359,7 +357,6 @@
                 request.done(function(data) {
                     let links = data.links
                     let linksKeys = Object.keys(links)
-
                     // For every link in topology
                     for(let i = 0; i < linksKeys.length; i++) {
                         let description = linksKeys[i]
@@ -372,9 +369,22 @@
                         } catch(error) {
                             // Description is id
                         }
-                        // Add the link as an option to edit items.
-                        _this.links_options.push({"value":linksKeys[i], "description":description})
+
+                        // Populate options for selected and available links
+                        let option = {"value": linksKeys[i], "description": description}
+                        if (_this.mw_links_set.delete(linksKeys[i])) {
+                            _this.sele_link_options.push(option)
+                        }
+                        else {
+                            _this.aval_link_options.push(option)
+                        }
                     }
+
+                    // Links that are deleted in topology but still exists in the MW
+                    _this.mw_links_set.forEach(link_id => {
+                        _this.sele_link_options.push({"value": link_id, "description": link_id})
+                    });
+                    _this.mw_links_set.clear()
                 })
                 request.fail(function(jqXHR, status) {
                     let notification = {
@@ -414,9 +424,22 @@
                         } catch(error) {
                             // Description is id
                         }
-                        // Add the switch as an option to edit items.
-                        _this.switches_options.push({"value":switchesKeys[i], "description":description})
+
+                        // Populate options for selected and available switches
+                        let option = {"value": switchesKeys[i], "description": description}
+                        if (_this.mw_switches_set.delete(switchesKeys[i])) {
+                            _this.sele_switch_options.push(option)
+                        }
+                        else {
+                            _this.aval_switch_options.push(option)
+                        }
                     }
+                
+                    // Switches that are deleted in topology but still exists in the MW
+                    _this.mw_switches_set.forEach(switch_id => {
+                        _this.sele_switch_options.push({"value": switch_id, "description": switch_id})
+                    });
+                    _this.mw_switches_set.clear()
                 })
                 request.fail(function(jqXHR, status) {
                     let notification = {
@@ -456,9 +479,21 @@
                         } catch(error) {
                             // Description is id
                         }
-                        // Add the interface as an option to edit items.
-                        _this.interfaces_options.push({"value":interfacesKeys[i], "description":description})
+
+                        // Populate options for selected and available interfaces
+                        let option = {"value": interfacesKeys[i], "description": description}
+                        if (_this.mw_interfaces_set.delete(interfacesKeys[i])) {
+                            _this.sele_interface_options.push(option)
+                        }
+                        else {
+                            _this.aval_interface_options.push(option)
+                        }
                     }
+                    // Interfaces that are deleted in topology but still exists in the MW
+                    _this.mw_interfaces_set.forEach(interfaces_id => {
+                        _this.sele_interface_options.push({"value": interfaces_id, "description": interfaces_id})
+                    });
+                    _this.mw_interfaces_set.clear()
                 })
                 request.fail(function(jqXHR, status) {
                     let notification = {
@@ -473,7 +508,7 @@
                 Determines what can be edited and what can not be edited
                 in a maintenance window.
             */
-            setEditable: function(data) {
+            setEditable: function() {
                 let editable = {
                     "Id": false,
                     "Start": true,
@@ -487,56 +522,15 @@
                 this.property_editable = editable
             },
             /*
-                Auto-selects items that are already part of the maintenance window as
-                items to be added to the maintenance window.
-            */
-            autoSelectItems: function() {
-                var auto_links = this.auto_items[0]
-                var auto_switches = this.auto_items[1]
-                var auto_interfaces = this.auto_items[2]
-
-                // If there are links to be auto-selected
-                if(auto_links) {
-                    // For every link to be auto-selected
-                    for(let i = 0; i < auto_links.length; i++) {
-                        // If the link is not in the chosen link list
-                        if(!this.chosen_links.includes(auto_links[i])) {
-                            // Add it.
-                            this.chosen_links.push(auto_links[i])
-                        }
-                    }
-                }
-                // If there are switches to be auto-selected
-                if(auto_switches) {
-                    // For every switch to be auto-selected
-                    for(let i = 0; i < auto_switches.length; i++) {
-                        // If the switch is not in the chosen switch list
-                        if(!this.chosen_switches.includes(auto_switches[i])) {
-                            // Add it.
-                            this.chosen_switches.push(auto_switches[i])
-                        }
-                    }
-                }
-                // If there are interfaces to be auto-selected
-                if(auto_interfaces) {
-                    // For every interface to be auto-selected
-                    for(let i = 0; i < auto_interfaces.length; i++) {
-                        // If the interface is not in the chosen interface list
-                        if(!this.chosen_interfaces.includes(auto_interfaces[i])) {
-                            // Add it.
-                            this.chosen_interfaces.push(auto_interfaces[i])
-                        }
-                    }
-                }
-            },
-            /*
                 Resets the auto-selected items.
             */
             resetItemSelection: function() {
-                this.auto_items = []
-                this.chosen_links = []
-                this.chosen_switches = []
-                this.chosen_interfaces = []
+                this.sele_chosen_links = []
+                this.sele_chosen_switches = []
+                this.sele_chosen_interfaces = []
+                this.aval_chosen_links = []
+                this.aval_chosen_switches = []
+                this.aval_chosen_interfaces = []
             },
             /*
                 Capitalizes the first letter of a given word.
@@ -587,7 +581,7 @@
             /*
             Extends a maintenance window.
             */
-            extendWindow() {
+            extendWindow: function() {
                 var _this = this
                 // Call the Maintenace API to extend the maintenance window.
                 var request = $.ajax({
@@ -624,7 +618,24 @@
                     // Notify on failure.
                     _this.$kytos.eventBus.$emit("setNotification", notification)
                 })           
-             },
+            },
+            /*
+                Button: Move components inside select boxes under "Selected" section to "Available" section
+            */
+            removeComponentsBT: function() {
+
+            },
+            /*
+                Button: Move components inside select boxes under "Available" section to "Selected" section
+            */
+            addComponentsBT: function() {
+
+            },
+            clickME: function() {
+                console.log("LINKS -> ", this.sele_link_options)
+                console.log("SWITCHES -> ", this.sele_switch_options)
+                console.log("INTERFACES -> ", this.sele_interface_options)
+            },
         },
         mounted() {
             // Loads the topology API first for editing the maintenance window.

--- a/ui/k-info-panel/edit_window.kytos
+++ b/ui/k-info-panel/edit_window.kytos
@@ -105,7 +105,6 @@
                 </div>
                 <div class = "window-extend-button">
                     <k-button title="Extend Window" @click="extendWindow"></k-button>
-                    <k-button title="CLICK ON ME" @click="clickME"></k-button>
                 </div>
                 <div class = "minute-input-field">
                     <k-input placeholder = "Enter minutes (click extend)" v-model:value ="minutes"></k-input>  
@@ -125,13 +124,6 @@
         data() {
             return {
                 window_data: [],
-                links_options: [],
-                switches_options: [],
-                interfaces_options: [],
-                chosen_links: [],
-                chosen_switches: [],
-                chosen_interfaces: [],
-                auto_items: [],
                 property_editable: [],
                 delete_window: false,
                 display: true,
@@ -139,9 +131,6 @@
                 mw_links_set: new Set(),
                 mw_switches_set: new Set(),
                 mw_interfaces_set: new Set(),
-                topo_links: [], 
-                topo_switches: [],
-                topo_interfaces: [],
                 sele_link_options: [],
                 sele_switch_options: [],
                 sele_interface_options: [],
@@ -182,36 +171,40 @@
                 var filteredInterfaces = []
                 
                 // For every chosen link
-                for(let item of this.chosen_links) {
+                for(let option of this.sele_link_options) {
                     // If the link is not a string
-                    if(typeof(item) != "string") {
+                    if(typeof(option.value) != "string") {
                         // Skip it.
                         continue
                     }
                     // Otherwise, add the link id to the list of links.
-                    filteredLinks.push(item)
+                    filteredLinks.push(option.value)
                 }
                 // For every chosen switch
-                for(let item of this.chosen_switches) {
+                for(let option of this.sele_switch_options) {
                     // If the switch is not a string
-                    if(typeof(item) != "string") {
+                    if(typeof(option.value) != "string") {
                         // Skip it.
                         continue
                     }
                     // Otherwise, add the switch id to the list of items.
-                    filteredSwitches.push(item)
+                    filteredSwitches.push(option.value)
                 }
                 // For every chosen interface
-                for(let item of this.chosen_interfaces) {
+                for(let option of this.sele_interface_options) {
                     // If the interface is not a string
-                    if(typeof(item) != "string") {
+                    if(typeof(option.value) != "string") {
                         // Skip it.
                         continue
                     }
                     // Otherwise, add the interface id to the list of links.
-                    filteredInterfaces.push(item)
+                    filteredInterfaces.push(option.value)
                 }
-                console.log("BEING SENT -> ", {
+                // Update the maitenance window with the new values.
+                var request = $.ajax({
+                    url: this.$kytos_server_api + "kytos/maintenance/v1/" + _this.window_data.Id,
+                    type: "PATCH",
+                    data: JSON.stringify({
                         "id": _this.window_data.Id,
                         "start": _this.window_data.Start,
                         "end": _this.window_data.End,
@@ -219,49 +212,34 @@
                         "links": filteredLinks,
                         "switches": filteredSwitches,
                         "interfaces": filteredInterfaces,
-                    })
-                // Update the maitenance window with the new values.
-                //var request = $.ajax({
-                //    url: this.$kytos_server_api + "kytos/maintenance/v1/" + _this.window_data.Id,
-                //    type: "PATCH",
-                //    data: JSON.stringify({
-                //        "id": _this.window_data.Id,
-                //        "start": _this.window_data.Start,
-                //        "end": _this.window_data.End,
-                //        "description": _this.window_data.Description,
-                //        "links": filteredLinks,
-                //        "switches": filteredSwitches,
-                //        "interfaces": filteredInterfaces,
-                //    }),
-                //    dataType: "json",
-                //    contentType: "application/json"
-                //})
-                //request.done( function(data) {
-                //    let notification = {
-                //        title: 'Window "' + _this.window_data.Id + '" updated.',
-                //        description: ''
-                //    }
-                //    // Notify on success.
-                //    _this.$kytos.eventBus.$emit("setNotification", notification)
-                //    // Refresh the window.
-                //    _this.resetItemSelection()
-                //    _this.loadMaintenanceWindow(_this.window_data.Id)
-                //})
-                //request.fail(function(jqXHR, status, error ) {
-                //    let error_message = JSON.parse(jqXHR.responseText)
-                //    if (error_message.hasOwnProperty('response')) {
-                //        error_message = error_message.response
-                //    } else if (error_message.hasOwnProperty('description')) {
-                //        error_message = error_message.description
-                //    }
-                //
-                //    let notification = {
-                //        title: 'Updated Window failed.',
-                //        description: 'Error updating window "' + _this.window_data.Id + '". ' + _this.capitalize(status) + ': ' +  error_message
-                //    }
-                //    // Notify on failure.
-                //    _this.$kytos.eventBus.$emit("setNotification", notification)
-                //})
+                    }),
+                    dataType: "json",
+                    contentType: "application/json"
+                })
+                request.done( function(data) {
+                    let notification = {
+                        title: 'Window "' + _this.window_data.Id + '" updated.',
+                        description: ''
+                    }
+                    // Notify on success.
+                    _this.$kytos.eventBus.$emit("setNotification", notification)
+                    _this.loadMaintenanceWindow(_this.window_data.Id)
+                })
+                request.fail(function(jqXHR, status, error ) {
+                    let error_message = JSON.parse(jqXHR.responseText)
+                    if (error_message.hasOwnProperty('response')) {
+                        error_message = error_message.response
+                    } else if (error_message.hasOwnProperty('description')) {
+                        error_message = error_message.description
+                    }
+                
+                    let notification = {
+                        title: 'Updated Window failed.',
+                        description: 'Error updating window "' + _this.window_data.Id + '". ' + _this.capitalize(status) + ': ' +  error_message
+                    }
+                    // Notify on failure.
+                    _this.$kytos.eventBus.$emit("setNotification", notification)
+                })
             },
             /*
                 Shows the modal delete window option.
@@ -270,7 +248,9 @@
                 this.delete_window = true
             },
             /*
-                Loads the given maintenance window into a table.
+                Loads the given maintenance window information and stores it.
+                In the UI it updates Id, Start, End, Description and Status.
+                Links, switches and Interfaces information is not updated.
             */
             loadMaintenanceWindow: function(id) {
                 var _this = this
@@ -547,17 +527,6 @@
                 this.property_editable = editable
             },
             /*
-                Resets the auto-selected items.
-            */
-            resetItemSelection: function() {
-                this.sele_chosen_links = []
-                this.sele_chosen_switches = []
-                this.sele_chosen_interfaces = []
-                this.aval_chosen_links = []
-                this.aval_chosen_switches = []
-                this.aval_chosen_interfaces = []
-            },
-            /*
                 Capitalizes the first letter of a given word.
             */
             capitalize: function(word) {
@@ -583,8 +552,6 @@
                     }
                     // Notify on success.
                     _this.$kytos.eventBus.$emit("setNotification", notification)
-                    // Refresh the window.
-                    _this.resetItemSelection()
                     _this.loadMaintenanceWindow(_this.window_data.Id)
                 })
                 request.fail(function(jqXHR, status) {
@@ -624,8 +591,6 @@
                     }
                     // Notify on success.
                     _this.$kytos.eventBus.$emit("setNotification", notification)
-                    // Refresh the window.
-                    _this.resetItemSelection()
                     _this.loadMaintenanceWindow(_this.window_data.Id)
                 })
                 request.fail(function(jqXHR, status) {


### PR DESCRIPTION
Closes #133

### Summary

- Separate Links, Switches, Interfaces from the `Maintenance Window Details` window into two columns `Selected` and `Available`.
- Added buttons under new columns to move Links, switches, interfaces around.

### Technical
Changed the order: 
- From loading topology components to select boxes and load MW to select option from boxes.
- To load MW first then load topology components and decide in which select box these components are going to be added by comparing them to the previously loaded MW information.

### Local Tests
Added, modified MWs

### End-to-End Tests
N/A

### Present look
<img width="1600" height="1348" alt="Screenshot_20250827_154629" src="https://github.com/user-attachments/assets/42a0c750-d854-46b5-9245-2678e57165f2" />

