### PR TITLE
Allowing seconds, hours and days when extending a window

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -18,7 +18,7 @@ tags:
   - name: Update
   - name: Delete
 paths:
-  '/maintenance/v1':
+  '/v1':
     get:
       tags:
         - List
@@ -71,7 +71,7 @@ paths:
                 properties:
                   mw_id:
                     type: string
-  '/maintenance/v1/{mw_id}':
+  '/v1/{mw_id}':
     get:
       tags:
         - List
@@ -137,7 +137,7 @@ paths:
           description: Invalid JSON.
         '404':
           description: Maintenance window not found.
-  '/maintenance/v1/{mw_id}/end':
+  '/v1/{mw_id}/end':
     patch:
       tags:
         - Update
@@ -158,7 +158,7 @@ paths:
           description: Maintenance window not found.
         '415':
           description: No JSON in request.
-  '/maintenance/v1/{mw_id}/extend':
+  '/v1/{mw_id}/extend':
     patch:
       tags:
         - Update
@@ -177,9 +177,16 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
+                seconds:
+                  type: integer
                 minutes:
-                  type: integer        
+                  type: integer
+                hours:
+                  type: integer
+                days:
+                  type: integer
       responses:
         '200':
           description: Maintenance window succesfully extended
@@ -196,7 +203,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '415':
           $ref: '#/components/responses/UnsupportedMediaType'
-  '/maintenance/v1/report':
+  '/v1/report':
     post:
       tags:
         - List

--- a/ui/k-info-panel/edit_window.kytos
+++ b/ui/k-info-panel/edit_window.kytos
@@ -106,8 +106,12 @@
                 <div class = "window-extend-button">
                     <k-button title="Extend Window" @click="extendWindow"></k-button>
                 </div>
-                <div class = "minute-input-field">
-                    <k-input placeholder = "Enter minutes (click extend)" v-model:value ="minutes"></k-input>  
+                <div class = "extend-input-field">
+                    <k-input placeholder = "SS" v-model:value ="extend_seconds"></k-input>
+                    <k-input placeholder = "MM" v-model:value ="extend_minutes"></k-input>
+                    <k-input placeholder = "HH" v-model:value ="extend_hours"></k-input>
+                    <k-input placeholder = "DD" v-model:value ="extend_days"></k-input>
+
                 </div>
             </div>
         </div>
@@ -127,7 +131,10 @@
                 property_editable: [],
                 delete_window: false,
                 display: true,
-                minutes: "",
+                extend_seconds: "",
+                extend_minutes: "",
+                extend_hours: "",
+                extend_days: "",
                 mw_links_set: new Set(),
                 mw_switches_set: new Set(),
                 mw_interfaces_set: new Set(),
@@ -575,7 +582,11 @@
                     type: "PATCH",
                     dataType: "json",
                     contentType: "application/json",
-                    data: JSON.stringify({"minutes": parseInt(_this.minutes),
+                    data: JSON.stringify({
+                        "seconds": parseInt(_this.extend_seconds) || 0,
+                        "minutes": parseInt(_this.extend_minutes) || 0,
+                        "hours": parseInt(_this.extend_hours) || 0,
+                        "days": parseInt(_this.extend_days) || 0,
                     }),
                 })
                 request.done(function(jqXHR, status) {
@@ -585,6 +596,7 @@
                     }
                     // Notify on success.
                     _this.$kytos.eventBus.$emit("setNotification", notification)
+                    _this.empty_extend_fields()
                     _this.loadMaintenanceWindow(_this.window_data.Id)
                 })
                 request.fail(function(jqXHR, status) {
@@ -650,6 +662,12 @@
                     this.aval_interface_options, this.sele_interface_options, this.sele_chosen_interfaces
                 )
             },
+            empty_extend_fields: function() {
+                this.extend_seconds = ""
+                this.extend_minutes = ""
+                this.extend_hours = ""
+                this.extend_days = ""
+            }
         },
         mounted() {
             // Loads the topology API first for editing the maintenance window.
@@ -686,22 +704,23 @@
 
     .window-buttons .window-buttons-bottom {
         margin-top: 1em;
+        display: flex;
+        flex-direction: row-reverse;
+        justify-content: flex-start;
     }
     
     .window-buttons .window-finish-button button {
-        float: right;
         background: #372C5E;
     }
     .window-buttons .window-extend-button button {
-        float: right;
         background: #372C5E;
-    } 
-    .minute-input-field {
-        float: right;
-        width: 200px;
-        display: flex; 
     }
-
+    .extend-input-field {
+        display: flex;
+    }
+    .extend-input-field input {
+        width: 40px;
+    }
     .maintenance-window-container table {
         border-collapse: collapse;
         width: 100%;


### PR DESCRIPTION
Closes #134

### Summary

API request `/api/kytos/maintenance/v1/{MW_id}/extend` modified to accept `seconds`, `hours` and `days`.
Added `k-inputs` to the window to edit MW so seconds, hours and days can be inserted.
Waiting for `ui` [PR](https://github.com/kytos-ng/ui/pull/242) so it can be prevented that letters are inserted in these boxes.


### Local Tests
Extended windows using seconds, hours, days and all together

### End-to-End Tests
N/A


### Screenshot
<img width="1221" height="1043" alt="Screenshot_20250904_160015" src="https://github.com/user-attachments/assets/15c246c2-5d35-4831-83d0-e88d937ec5b3" />
